### PR TITLE
Fix CRM-21347 Joomla auto-save of features fails

### DIFF
--- a/libraries/joomla/form/fields/civiperms.php
+++ b/libraries/joomla/form/fields/civiperms.php
@@ -47,7 +47,7 @@ class JFormFieldCiviperms extends JFormFieldRules {
   protected function getInput() {
     JHtml::_('bootstrap.tooltip');
     // Add Javascript for permission change
-    JHtml::_('script', 'system/permissions.js', array('version' => 'auto', 'relative' => true));
+    JHtml::_('script', 'system/permissions.js', FALSE, TRUE);
     // Load JavaScript message titles
     JText::script('ERROR');
     JText::script('WARNING');


### PR DESCRIPTION
I think JHTML::_() needs separate arguments rather than an array of named parameters. This at least matches what I see in other Joomla code, and it works to solve the problem.